### PR TITLE
widen `max_measurement` to `uint64`

### DIFF
--- a/draft-ietf-ppm-l1-bound-sum.md
+++ b/draft-ietf-ppm-l1-bound-sum.md
@@ -264,13 +264,13 @@ using the syntax definitions from {{Section 3 of !RFC8446}}.
 ~~~ tls-presentation
 struct {
   uint32 length;
-  uint32 max_value;
+  uint64 max_value;
   uint32 chunk_length;
 } Prio3L1BoundSumConfig;
 ~~~
 {: #fig-config title="VDAF Configuration Encoding for Prio3L1BoundSum"}
 
-This configuration is three 32-bit integers,
+This configuration is three integers,
 each in network byte order,
 with semantics described in {{def}},
 as follows:


### PR DESCRIPTION
Following the rationale in [1], the `max_measurement` configuration parameter is widened to 64 bits.

[1]: https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/777